### PR TITLE
feat(commands): Inspect command for easier debugging

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 }
 
 def targetJavaVersion = 17
+compileJava.options.encoding = 'UTF-8'
 java {
     def javaVersion = JavaVersion.toVersion(targetJavaVersion)
     sourceCompatibility = javaVersion
@@ -41,6 +42,7 @@ tasks.withType(JavaCompile).configureEach {
     if (targetJavaVersion >= 10 || JavaVersion.current().isJava10Compatible()) {
         options.release.set(targetJavaVersion)
     }
+    options.encoding = 'UTF-8'
 }
 
 processResources {

--- a/src/main/java/dev/avatcher/cinnamon/Cinnamon.java
+++ b/src/main/java/dev/avatcher/cinnamon/Cinnamon.java
@@ -3,6 +3,8 @@ package dev.avatcher.cinnamon;
 import com.google.common.base.Preconditions;
 import dev.avatcher.cinnamon.block.listeners.NoteblockListener;
 import dev.avatcher.cinnamon.commands.CGiveCommand;
+import dev.avatcher.cinnamon.commands.CommandBase;
+import dev.avatcher.cinnamon.commands.InspectCommand;
 import dev.avatcher.cinnamon.exceptions.CinnamonRuntimeException;
 import dev.avatcher.cinnamon.item.listeners.ItemEventListener;
 import dev.avatcher.cinnamon.resources.CinnamonResources;
@@ -11,7 +13,6 @@ import dev.avatcher.cinnamon.resources.ResourcepackServer;
 import dev.avatcher.cinnamon.resources.source.JarCinnamonResources;
 import dev.jorel.commandapi.CommandAPI;
 import dev.jorel.commandapi.CommandAPIBukkitConfig;
-import dev.jorel.commandapi.CommandAPICommand;
 import lombok.Getter;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -102,7 +103,8 @@ public final class Cinnamon extends JavaPlugin {
                 new NoteblockListener()
         );
         this.registerCommands(
-                new CGiveCommand().getCommandAPICommand()
+                new CGiveCommand(),
+                new InspectCommand()
         );
         // Runs code AFTER all the plugins are loaded
         this.getServer().getScheduler().scheduleSyncDelayedTask(this, this::initializeResourcepackServer);
@@ -129,9 +131,9 @@ public final class Cinnamon extends JavaPlugin {
      *
      * @param commands CommandAPI commands
      */
-    private void registerCommands(CommandAPICommand... commands) {
+    private void registerCommands(CommandBase... commands) {
         for (var command : commands) {
-            command.register();
+            command.getCommandApiCommand().register();
         }
     }
 

--- a/src/main/java/dev/avatcher/cinnamon/block/CBlock.java
+++ b/src/main/java/dev/avatcher/cinnamon/block/CBlock.java
@@ -1,5 +1,6 @@
 package dev.avatcher.cinnamon.block;
 
+import dev.avatcher.cinnamon.Cinnamon;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -54,8 +55,14 @@ public class CBlock {
 
     public static Optional<CBlock> of(Block block) {
         if (!isCustom(block)) return Optional.empty();
-        // TODO: Store custom blocks in Resources manager
-        return Optional.empty();
+        NoteBlock blockData = (NoteBlock) block.getBlockData();
+        NoteblockTune blockTune = new NoteblockTune(blockData.getNote().getId(), blockData.getInstrument().getType());
+        return Cinnamon.getInstance().getResourcesManager()
+                .getCustomBlocks()
+                .getValues()
+                .stream()
+                .filter(cBlock -> cBlock.getTune().equals(blockTune))
+                .findAny();
     }
 
     @Builder

--- a/src/main/java/dev/avatcher/cinnamon/commands/CGiveCommand.java
+++ b/src/main/java/dev/avatcher/cinnamon/commands/CGiveCommand.java
@@ -26,7 +26,7 @@ import java.util.Optional;
  *
  * @see CItem
  */
-public class CGiveCommand {
+public class CGiveCommand implements CommandBase {
     /**
      * Command's in-game name
      */
@@ -92,13 +92,12 @@ public class CGiveCommand {
         }
     }
 
-    /**
-     * Constructs a {@link dev.jorel.commandapi.CommandAPICommand} instance
-     * for this command.
-     *
-     * @return A {@link CommandAPICommand} instance
-     */
-    public CommandAPICommand getCommandAPICommand() {
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public CommandAPICommand getCommandApiCommand() {
         return new CommandAPICommand(NAME)
                 .withShortDescription("Gives a custom item")
                 .withPermission(CommandPermission.OP)

--- a/src/main/java/dev/avatcher/cinnamon/commands/CGiveCommand.java
+++ b/src/main/java/dev/avatcher/cinnamon/commands/CGiveCommand.java
@@ -4,9 +4,9 @@ import dev.avatcher.cinnamon.Cinnamon;
 import dev.avatcher.cinnamon.item.CItem;
 import dev.jorel.commandapi.CommandAPICommand;
 import dev.jorel.commandapi.CommandPermission;
+import dev.jorel.commandapi.arguments.EntitySelectorArgument;
 import dev.jorel.commandapi.arguments.IntegerArgument;
 import dev.jorel.commandapi.arguments.NamespacedKeyArgument;
-import dev.jorel.commandapi.arguments.PlayerArgument;
 import dev.jorel.commandapi.arguments.SafeSuggestions;
 import dev.jorel.commandapi.executors.CommandArguments;
 import net.kyori.adventure.text.Component;
@@ -18,6 +18,7 @@ import org.bukkit.SoundCategory;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
+import java.util.Collection;
 import java.util.Optional;
 
 /**
@@ -38,8 +39,8 @@ public class CGiveCommand {
      * @param args   Command arguments
      */
     public void executePlayer(Player player, CommandArguments args) {
-        Player target = (Player) args.get("target");
-        if (target == null) {
+        Collection<Player> targets = args.getUnchecked("target");
+        if (targets == null) {
             player.sendMessage(Component.text("Invalid target").color(NamedTextColor.RED));
             return;
         }
@@ -54,27 +55,41 @@ public class CGiveCommand {
             return;
         }
         CItem cItem = optionalCustomItem.get();
-
         int amount = (Integer) args.getOptional("amount").orElse(1);
-        if (amount < 1 || amount > 64) {
-            player.sendMessage(Component.text("Invalid item amount: " + amount + "\nOnly values between 1 and 64 are allowed.").color(NamedTextColor.RED));
+        if (amount > 6400) {
+            player.sendMessage(Component.translatable("commands.give.failed.toomanyitems")
+                    .args(Component.text(64000), cItem.getName())
+                    .color(NamedTextColor.RED));
             return;
         }
-
         ItemStack itemStack = cItem.getItemStack();
         itemStack.setAmount((Integer) args.getOptional("amount").orElse(1));
-        target.getInventory().addItem(itemStack);
-
-        target.playSound(target, Sound.ENTITY_ITEM_PICKUP, SoundCategory.MASTER, .25f, 2f);
-        Bukkit.getServer().broadcast(
-                Component.translatable("commands.give.success.single")
-                        .args(
-                                Component.text(itemStack.getAmount()),
-                                Component.translatable("chat.square_brackets")
-                                        .args(cItem.getName()),
-                                Component.text(target.getName())
-                        )
-        );
+        for (var target : targets) {
+            target.getInventory().addItem(itemStack);
+            target.playSound(target, Sound.ENTITY_ITEM_PICKUP, SoundCategory.MASTER, .25f, 2f);
+        }
+        if (targets.size() > 1) {
+            Bukkit.getServer().broadcast(
+                    Component.translatable("commands.give.success.multiple")
+                            .args(
+                                    Component.text(amount),
+                                    Component.translatable("chat.square_brackets")
+                                            .args(cItem.getName()),
+                                    Component.text(targets.size())
+                            )
+            );
+        } else {
+            Player target = targets.stream().findFirst().orElseThrow();
+            Bukkit.getServer().broadcast(
+                    Component.translatable("commands.give.success.single")
+                            .args(
+                                    Component.text(amount),
+                                    Component.translatable("chat.square_brackets")
+                                            .args(cItem.getName()),
+                                    Component.text(target.getName())
+                            )
+            );
+        }
     }
 
     /**
@@ -88,7 +103,7 @@ public class CGiveCommand {
                 .withShortDescription("Gives a custom item")
                 .withPermission(CommandPermission.OP)
                 .withArguments(
-                        new PlayerArgument("target"),
+                        new EntitySelectorArgument.ManyPlayers("target"),
                         new NamespacedKeyArgument("item")
                                 .replaceSafeSuggestions(SafeSuggestions.suggest(info ->
                                         Cinnamon.getInstance().getResourcesManager().getCustomItems().getKeys()
@@ -98,7 +113,7 @@ public class CGiveCommand {
                                 ))
                 )
                 .withOptionalArguments(
-                        new IntegerArgument("amount", 1, 64)
+                        new IntegerArgument("amount", 1)
                 )
                 .executesPlayer(this::executePlayer);
     }

--- a/src/main/java/dev/avatcher/cinnamon/commands/CGiveCommand.java
+++ b/src/main/java/dev/avatcher/cinnamon/commands/CGiveCommand.java
@@ -38,7 +38,6 @@ public class CGiveCommand {
      * @param args   Command arguments
      */
     public void executePlayer(Player player, CommandArguments args) {
-        player.sendMessage("CINNAMON COMMAND");
         Player target = (Player) args.get("target");
         if (target == null) {
             player.sendMessage(Component.text("Invalid target").color(NamedTextColor.RED));

--- a/src/main/java/dev/avatcher/cinnamon/commands/CommandBase.java
+++ b/src/main/java/dev/avatcher/cinnamon/commands/CommandBase.java
@@ -1,0 +1,20 @@
+package dev.avatcher.cinnamon.commands;
+
+import dev.jorel.commandapi.CommandAPICommand;
+
+public interface CommandBase {
+    /**
+     * Gets the name of the command.
+     *
+     * @return Name of the command
+     */
+    String getName();
+
+    /**
+     * Constructs a {@link dev.jorel.commandapi.CommandAPICommand} instance
+     * for the command, that can be used to register it.
+     *
+     * @return A {@link CommandAPICommand} instance
+     */
+    CommandAPICommand getCommandApiCommand();
+}

--- a/src/main/java/dev/avatcher/cinnamon/commands/InspectCommand.java
+++ b/src/main/java/dev/avatcher/cinnamon/commands/InspectCommand.java
@@ -1,0 +1,112 @@
+package dev.avatcher.cinnamon.commands;
+
+import dev.avatcher.cinnamon.Cinnamon;
+import dev.avatcher.cinnamon.item.CItem;
+import dev.avatcher.cinnamon.resources.CustomModelData;
+import dev.jorel.commandapi.CommandAPICommand;
+import dev.jorel.commandapi.CommandPermission;
+import dev.jorel.commandapi.executors.CommandArguments;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.persistence.PersistentDataType;
+
+import java.util.Optional;
+
+public class InspectCommand implements CommandBase {
+    public static final String NAME = "inspect";
+    public static final String SUBCOMMAND_ITEM = "item";
+    public static final String SUBCOMMAND_BLOCK = "block";
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public CommandAPICommand getCommandApiCommand() {
+        return new CommandAPICommand("inspect")
+                .withPermission(CommandPermission.OP)
+                .withSubcommand(new CommandAPICommand(SUBCOMMAND_ITEM)
+                        .executesPlayer(this::inspectItem)
+                )
+                .withSubcommand(new CommandAPICommand(SUBCOMMAND_BLOCK)
+                        .executesPlayer(this::inspectBlock)
+                );
+    }
+
+    private void inspectItem(Player player, CommandArguments args) {
+        ItemStack itemStack = player.getInventory().getItemInMainHand();
+        if (itemStack.getType() == Material.AIR) {
+            player.sendMessage(Component.text("No item in hand to inspect").color(NamedTextColor.RED));
+            return;
+        }
+        MiniMessage miniMessage = MiniMessage.miniMessage();
+        Component message = Component.empty()
+                .color(NamedTextColor.GRAY)
+                .append(itemStack.displayName()
+                        .color(NamedTextColor.WHITE))
+                .append(Component.newline());
+
+        if (!CItem.isCustom(itemStack)) {
+            player.sendMessage(
+                    message.append(Component.text("└ Regular item").color(NamedTextColor.GRAY)));
+            return;
+        }
+        Optional<CItem> cItemOptional = CItem.of(itemStack);
+        if (cItemOptional.isPresent()) {
+            message = message
+                    .append(miniMessage.deserialize("<gray>├ Id: <gray><white>" + cItemOptional.get().getIdentifier() + "</white>\n"))
+                    .append(this.inspectItemModel(itemStack, cItemOptional.get()));
+        } else {
+            String itemId = itemStack.getItemMeta().getPersistentDataContainer().get(CItem.IDENTIFIER_KEY, PersistentDataType.STRING);
+            message = message.append(miniMessage.deserialize("<gray>└ Id: </gray><red>" + itemId + "\n   ⚠ Invalid identifier</red>\n"));
+        }
+        player.sendMessage(message);
+    }
+
+    private Component inspectItemModel(ItemStack itemStack, CItem cItem) {
+        int actualModelNum = itemStack.getItemMeta().getCustomModelData();
+        boolean isRightModel = actualModelNum == cItem.getModel().numeric();
+
+        String messageString;
+        if (isRightModel) {
+            messageString = """
+                    └ <gray>Model:</gray>
+                      ├ <gray>Id:</gray> <white>%s</white>
+                      └ <gray>Num:</gray> <white>%s</white>
+                    """
+            .formatted(
+                    cItem.getModel().identifier(),
+                    cItem.getModel().numeric());
+        } else {
+            CustomModelData actualModel = Cinnamon.getInstance().getResourcesManager().getCustomModelData().getValues()
+                    .stream()
+                    .filter(model -> model.numeric() == actualModelNum).findFirst()
+                    .orElse(null);
+            String actualModelName = actualModel == null
+                    ? "[not found]"
+                    : actualModel.identifier().toString();
+            messageString = """
+                    ├ <gray>Model:</gray>
+                      ├ <gray>Id:</gray> <red>%s</red>
+                      │  └ <dark_gray>(exp. %s)</dark_gray>
+                      └ <gray>Num:</gray> <red>%s</red>
+                         └ <dark_gray>(exp. %s)</dark_gray>
+                    """
+            .formatted(
+                    actualModelName,
+                    cItem.getModel().identifier(),
+                    actualModelNum,
+                    cItem.getModel().numeric());
+        }
+        return MiniMessage.miniMessage().deserialize(messageString);
+    }
+
+    private void inspectBlock(Player player, CommandArguments args) {
+        player.sendMessage(Component.text("Not implemented"));
+    }
+}


### PR DESCRIPTION
# Features
- Added `/inspect` command with two subcommands
  - `/inspect item` that prints information about custom item in the hand
  - `/inspect block` that prints information about targetted custom block
 
# Fixes
- Removed debug message in `/cgive` command
- Implemented `CBlock.of(ItemStack)` static method